### PR TITLE
Resolve crash when loading equipment through debug scene

### DIFF
--- a/scripts/equipable_editor.gd
+++ b/scripts/equipable_editor.gd
@@ -46,8 +46,9 @@ func _ready() -> void:
 		var file_name = dir.get_next()
 		while file_name !="":
 			var button : Button = Button.new()
+			var scene = load("res://objects/equipables/" + file_name)
 			button.text = file_name
-			button.pressed.connect(self.fileSelect.bind(button))
+			button.pressed.connect(self.fileSelect.bind(button, scene))
 			vbox.add_child(button)
 			file_name=dir.get_next()
 	for x in buttons.get_children():
@@ -56,11 +57,8 @@ func _ready() -> void:
 	for x in loop:
 		x.pressed.connect(self._usage_edit.bind(x))
 
-func fileSelect(_button : Button):
-	vbox.get_parent().queue_free()
-	var packedEquip = load("res://objects/equipables/"+_button.text)
-	print(packedEquip)
-	var item = packedEquip.instantiate()
+func fileSelect(_button : Button, scene : PackedScene):
+	var item = scene.instantiate()
 	add_child(item)
 	equip = item
 	
@@ -82,6 +80,7 @@ func fileSelect(_button : Button):
 	shou2.get_child(0).position = Vector2(equip.offset,0)
 	
 	reset()
+	vbox.get_parent().queue_free()
 
 func direction_button(button : Button):
 	if selected == "": return;


### PR DESCRIPTION
# What happened?
No idea, I actually dug into running Godot from the console, as _that_ can reveal more information. Unfortunately, that was pretty useless:
```
================================================================
CrashHandlerException: Program crashed with signal 11
Engine version: Godot Engine v4.3.stable.official (77dcf97d82cbfe4e4615475fa52ca03da645dbd8)
Dumping the backtrace. Please include this when reporting the bug to the project developer.
[1] error(-1): no debug info in PE/COFF executable
[2] error(-1): no debug info in PE/COFF executable
[3] error(-1): no debug info in PE/COFF executable
... Cut for brevity ...
[52] error(-1): no debug info in PE/COFF executable
[53] error(-1): no debug info in PE/COFF executable
[54] error(-1): no debug info in PE/COFF executable
-- END OF BACKTRACE --
================================================================
```

What I can infer from debug printing and breakpoints, is that it's _absolutely_ the load() call, so what I've done here is changed _when_ loading happens. Now it loads the scenes, when setting up buttons, and binds that to the function call. This is a tad bit more flexible, as now you can give your buttons a fancier name.

# Other thoughts
You might find some interest in [Resource Groups](https://godotengine.org/asset-library/asset/2348). In the past when working with debug menus I've defined objects as a resource group and built the buttons based on this. A really really basic use case I've done with resource groups you can find [over here](https://github.com/Pontax1122/NoBugsAllowed/blob/main/scripts/spawner.gd), it just spawns enemies from a group of resources defined as NPCs

Your approach is certainly more automatic though, as just having the files in the right spot makes it work. But resources would give you more flexibility in giving more information to the button, like a name. I certainly didn't dig too deep outside of the error to know if you've already got something set up like that though.